### PR TITLE
Add dependency injection annotation

### DIFF
--- a/src/angular-google-staticmaps.js
+++ b/src/angular-google-staticmaps.js
@@ -58,7 +58,7 @@
         }, '');
       };
     })
-    .directive('staticGmap', function ($parse) {
+    .directive('staticGmap', ['$parse', function ($parse) {
       return {
         template: '<img alt="Google Map">',
         replace: true,
@@ -88,5 +88,5 @@
           el.src = ctrl.buildSourceString(attrs, markers);
         }
       };
-    });
+    }]);
 }());


### PR DESCRIPTION
This change would allow the module/directive to be used with a minifier without using ngmin or ng-annotate beforehand.
